### PR TITLE
patch ldap_helper.php to allow ldapv3 with ldaps encryption

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apk --update add --virtual .build-deps tar curl composer && \
     curl -SsL "https://github.com/LimeSurvey/LimeSurvey/archive/${SURVEY_VERSION}.tar.gz" | \
         tar xz -C /var/www/app/ -X /.tarignore --strip-components=1 && \
     curl -SsL -o /etc/php7/browscap.ini https://browscap.org/stream?q=Lite_PHP_BrowsCapINI && \
+    patch /var/www/app/application/helpers/ldap_helper.php /ldap_helper.patch && \
     mkdir -p /var/www/app/upload/surveys && \
     mkdir -p /var/www/app/uploadstruct && \
     cp -a /var/www/app/upload/* /var/www/app/uploadstruct && \

--- a/overlay/ldap_helper.patch
+++ b/overlay/ldap_helper.patch
@@ -1,0 +1,15 @@
+--- ldap_helper_new.php
++++ ldap_helper.php
+@@ -27,7 +27,11 @@
+     } else {
+         $ds = false;
+         if ($ldap_server[$server_id]['protoversion'] == 'ldapv3' && $ldap_server[$server_id]['encrypt'] != 'ldaps') {
+-            $ds = ldap_connect($ldap_server[$server_id]['server'], $ldap_server[$server_id]['port']);
++            if ($ldap_server[$server_id]['encrypt'] == 'ldaps') {
++                $ds = ldap_connect("ldaps://".$ldap_server[$server_id]['server'], $ldap_server[$server_id]['port']);
++            } else {
++                $ds = ldap_connect($ldap_server[$server_id]['server'], $ldap_server[$server_id]['port']);
++            }
+             ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3);
+
+             if (!$ldap_server[$server_id]['referrals']) {


### PR DESCRIPTION
`application/helpers/ldap_helper.php` handles the LDAP connection and does not allow using ldapv3 + LDAPS encryption, but exactly this combination is required in some cases. LDAP queries working as expected after patching the file.